### PR TITLE
Rename the request URL to match the renamed servlet

### DIFF
--- a/sanitation/collection.py
+++ b/sanitation/collection.py
@@ -56,7 +56,7 @@ def get_collection_date(coll_type_str, addr_str):
 
 
 def _make_request(addr):
-    URL = "https://itmdapps.milwaukee.gov/DPWServletsPublic/garbage_day"
+    URL = "https://itmdapps.milwaukee.gov/DpwServletsPublic/garbage_day"
     PARAMS = {"embed": "Y"}
     data = {
         "laddr": addr.st_num,


### PR DESCRIPTION
The Milwaukee DPW changed the URI for the form submission and it broke the retrieval of collection dates. This fixes that URI.